### PR TITLE
project: add test Sisu index goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Include the plugin in your project's `pom.xml` file:
         <plugin>
             <groupId>dev.ybrig.concord</groupId>
             <artifactId>concord-maven-plugin</artifactId>
-            <version>0.0.37</version>
+            <version>0.0.38</version>
             <configuration>
                 <concordVersion>2.19.0</concordVersion>
             </configuration>
@@ -36,6 +36,16 @@ Include the plugin in your project's `pom.xml` file:
         </plugin>
     </plugins>
 </build>
+```
+
+If your plugin tests define Sisu components in `src/test/java`, add the `test-sisu-index` goal as well:
+
+```xml
+<execution>
+    <goals>
+        <goal>test-sisu-index</goal>
+    </goals>
+</execution>
 ```
 
 ### Example Output
@@ -57,4 +67,3 @@ Using the Concord Dependency Validator plugin helps to:
 
 - **Maintain Consistency**: Ensures dependencies are aligned with Concord’s runtime environment requirements.
 - **Reduce Errors**: Minimizes runtime issues due to version mismatches or incorrectly scoped dependencies.
-

--- a/src/main/java/com/walmartlabs/concord/maven/plugin/AbstractSisuIndexMojo.java
+++ b/src/main/java/com/walmartlabs/concord/maven/plugin/AbstractSisuIndexMojo.java
@@ -1,0 +1,135 @@
+package com.walmartlabs.concord.maven.plugin;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2020 - 2024 Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.project.MavenProject;
+
+import org.codehaus.plexus.util.Scanner;
+import org.codehaus.plexus.util.io.CachingWriter;
+import org.eclipse.sisu.space.SisuIndex;
+import org.eclipse.sisu.space.URLClassSpace;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+abstract class AbstractSisuIndexMojo extends AbstractMojo {
+
+    private static final String INDEX_FOLDER = "META-INF/sisu/";
+
+    private final MavenProject project;
+    private final BuildContext buildContext;
+    private final File outputDirectory;
+    private final List<File> classPathDirectories;
+
+    protected AbstractSisuIndexMojo(BuildContext buildContext, MavenProject project, File outputDirectory, List<File> classPathDirectories) {
+        this.buildContext = buildContext;
+        this.project = project;
+        this.outputDirectory = outputDirectory;
+        this.classPathDirectories = classPathDirectories;
+    }
+
+    @Override
+    public void execute() {
+        synchronized (project) {
+            new SisuIndex(outputDirectory) {
+                @Override
+                protected Writer getWriter(String path) throws IOException {
+                    Path p = outputDirectory.toPath().resolve(path);
+                    Path d = p.getParent();
+                    if (!Files.isDirectory(d)) {
+                        Files.createDirectories(d);
+                    }
+                    return new CachingWriter(p, StandardCharsets.UTF_8);
+                }
+
+                @Override
+                protected void info(String message) {
+                    getLog().info(message);
+                }
+
+                @Override
+                protected void warn(String message) {
+                    getLog().warn(message);
+                }
+            }.index(new URLClassSpace(getProjectClassLoader(), getIndexPath()));
+            buildContext.refresh(new File(outputDirectory, INDEX_FOLDER));
+        }
+    }
+
+    private ClassLoader getProjectClassLoader() {
+        List<URL> classPath = new ArrayList<>();
+        for (File directory : classPathDirectories) {
+            appendDirectoryToClassPath(classPath, directory);
+        }
+        for (Artifact artifact : project.getArtifacts()) {
+            appendFileToClassPath(classPath, artifact.getFile());
+        }
+        return URLClassLoader.newInstance(classPath.toArray(new URL[0]));
+    }
+
+    private void appendDirectoryToClassPath(List<URL> urls, File directory) {
+        if (!directory.isDirectory()) {
+            getLog().debug("Path " + directory + " does not exist or is no directory");
+            return;
+        }
+
+        Scanner scanner = buildContext.newScanner(directory);
+        scanner.setIncludes(new String[]{"**/*.class"});
+        scanner.scan();
+        String[] includedFiles = scanner.getIncludedFiles();
+        if (includedFiles != null && includedFiles.length > 0) {
+            getLog().debug("Found at least one class file in " + directory);
+            appendFileToClassPath(urls, directory);
+        } else {
+            getLog().debug("No class files found in " + directory);
+        }
+    }
+
+    private void appendFileToClassPath(List<URL> urls, File file) {
+        if (file == null) {
+            return;
+        }
+
+        try {
+            urls.add(file.toURI().toURL());
+        } catch (MalformedURLException e) {
+            getLog().warn(e.getLocalizedMessage());
+        }
+    }
+
+    private URL[] getIndexPath() {
+        List<URL> indexPath = new ArrayList<>();
+        appendDirectoryToClassPath(indexPath, outputDirectory);
+        return indexPath.toArray(new URL[0]);
+    }
+}

--- a/src/main/java/com/walmartlabs/concord/maven/plugin/TestSisuIndexMojo.java
+++ b/src/main/java/com/walmartlabs/concord/maven/plugin/TestSisuIndexMojo.java
@@ -31,16 +31,20 @@ import java.io.File;
 import java.util.List;
 
 @SuppressWarnings({"UnusedDeclaration"})
-@Mojo(name = "sisu-index", defaultPhase = LifecyclePhase.PROCESS_CLASSES,
-        requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true)
-public class SisuIndexMojo extends AbstractSisuIndexMojo {
+@Mojo(name = "test-sisu-index", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES,
+        requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
+public class TestSisuIndexMojo extends AbstractSisuIndexMojo {
 
     @Inject
-    public SisuIndexMojo(BuildContext buildContext, MavenProject project) {
-        super(buildContext, project, outputDirectory(project), List.of(outputDirectory(project)));
+    public TestSisuIndexMojo(BuildContext buildContext, MavenProject project) {
+        super(buildContext, project, testOutputDirectory(project), List.of(testOutputDirectory(project), outputDirectory(project)));
     }
 
     private static File outputDirectory(MavenProject project) {
         return new File(project.getBuild().getOutputDirectory());
+    }
+
+    private static File testOutputDirectory(MavenProject project) {
+        return new File(project.getBuild().getTestOutputDirectory());
     }
 }

--- a/src/test/java/com/walmartlabs/concord/maven/plugin/SisuIndexMojoTest.java
+++ b/src/test/java/com/walmartlabs/concord/maven/plugin/SisuIndexMojoTest.java
@@ -1,0 +1,106 @@
+package com.walmartlabs.concord.maven.plugin;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2020 - 2024 Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonatype.plexus.build.incremental.DefaultBuildContext;
+
+import javax.inject.Named;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SisuIndexMojoTest {
+
+    @TempDir
+    private Path workDir;
+
+    @Test
+    public void testMainIndex() throws Exception {
+        Path outputDirectory = workDir.resolve("classes");
+        Path testOutputDirectory = workDir.resolve("test-classes");
+        copyClass(NamedMainComponent.class, outputDirectory);
+        copyClass(NamedTestComponent.class, testOutputDirectory);
+
+        new SisuIndexMojo(new DefaultBuildContext(), project(outputDirectory, testOutputDirectory)).execute();
+
+        String index = readIndex(outputDirectory);
+        assertTrue(index.contains(NamedMainComponent.class.getName()));
+        assertFalse(index.contains(NamedTestComponent.class.getName()));
+    }
+
+    @Test
+    public void testTestIndex() throws Exception {
+        Path outputDirectory = workDir.resolve("classes");
+        Path testOutputDirectory = workDir.resolve("test-classes");
+        copyClass(NamedMainComponent.class, outputDirectory);
+        copyClass(NamedTestComponent.class, testOutputDirectory);
+
+        new TestSisuIndexMojo(new DefaultBuildContext(), project(outputDirectory, testOutputDirectory)).execute();
+
+        String index = readIndex(testOutputDirectory);
+        assertTrue(index.contains(NamedTestComponent.class.getName()));
+        assertFalse(index.contains(NamedMainComponent.class.getName()));
+    }
+
+    private static MavenProject project(Path outputDirectory, Path testOutputDirectory) {
+        Build build = new Build();
+        build.setOutputDirectory(outputDirectory.toString());
+        build.setTestOutputDirectory(testOutputDirectory.toString());
+
+        MavenProject project = new MavenProject();
+        project.setBuild(build);
+        project.setArtifacts(Set.of());
+        return project;
+    }
+
+    private static void copyClass(Class<?> type, Path outputDirectory) throws IOException {
+        String name = type.getName().replace('.', '/') + ".class";
+        Path target = outputDirectory.resolve(name);
+        Files.createDirectories(target.getParent());
+        try (InputStream in = type.getClassLoader().getResourceAsStream(name)) {
+            if (in == null) {
+                throw new IOException("Class file not found: " + name);
+            }
+            Files.copy(in, target);
+        }
+    }
+
+    private static String readIndex(Path outputDirectory) throws IOException {
+        return Files.readString(outputDirectory.resolve("META-INF/sisu/javax.inject.Named"));
+    }
+
+    @Named("main")
+    public static class NamedMainComponent {
+    }
+
+    @Named("test")
+    public static class NamedTestComponent {
+    }
+}


### PR DESCRIPTION
Adds a `test-sisu-index` goal that indexes Sisu components from `target/test-classes` during `process-test-classes` with test-scope dependency resolution.

This lets Concord plugin tests expose test-only fixtures such as mocked tasks without falling back to `sisu-maven-plugin` for test indexing.

Validation:
- `./mvnw -B test`
- `./mvnw -B verify`